### PR TITLE
Filters css improvements

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -81,24 +81,7 @@ a {
       opacity: 70%;
     }
 
-    button {
-      min-height: 40px;
-      font-size: medium;
-      font-family: "Rubik";
-      border-radius: 10px;
-      padding-left: 15px;
-      padding-right: 15px;
-      background-color: hsl(222, 63%, 10%);
-      border: none;
-      outline: 1px solid hsl(222, 50%, 30%);
-      transition: 0.2s ease;
-      &:hover {
-        background-color: hsl(222, 63%, 15%);
-      }
-      &:active {
-        background-color: hsl(222, 63%, 20%);
-      }
-    }
+    button,
     select {
       min-height: 40px;
       font-size: medium;
@@ -110,7 +93,11 @@ a {
       border: none;
       outline: 1px solid hsl(222, 50%, 30%);
       transition: 0.2s ease;
-      &:hover {
+      color: #ffffff;
+      cursor: pointer;
+
+      &:hover,
+      &:focus-visible {
         background-color: hsl(222, 63%, 15%);
       }
       &:active {


### PR DESCRIPTION
Refactor - css for button/select filters was duplicated. Extracted to 1 css rule


a11y - The filter text wasn't readable. Changed to white + added focus-visible so that there's a clear state when focusing with keyboard