### PR TITLE
[hotfix-data-null-issue] fixed null values in api

### DIFF
--- a/src/server/services/dataManager.service.ts
+++ b/src/server/services/dataManager.service.ts
@@ -276,6 +276,8 @@ export async function fetchComps(allComps: { name: string }[]) {
   });
 }
 
+const storeNonNulls = (arr: unknown[]) => arr.filter((n) => !!n);
+
 export async function mainDataFetch(resetData?: boolean) {
   let isFromDB = false;
   try {
@@ -297,7 +299,7 @@ export async function mainDataFetch(resetData?: boolean) {
       return {
         success,
         allComps,
-        projects: allGqlProjects.filter((project: any) => project !== null),
+        projects: allGqlProjects,
         companies: allGqlCompanies,
         allLanguages,
         isFromDB,
@@ -333,8 +335,8 @@ export async function mainDataFetch(resetData?: boolean) {
     const saveResult = await setRedisVal(JSON_DATA_STORE_KEY, {
       success,
       allComps,
-      allGqlProjects,
-      allGqlCompanies,
+      allGqlProjects: storeNonNulls(allGqlProjects),
+      allGqlCompanies: storeNonNulls(allGqlCompanies),
       allLanguages,
       createDate: new Date()
     });
@@ -348,8 +350,8 @@ export async function mainDataFetch(resetData?: boolean) {
     return {
       success,
       allComps,
-      projects: allGqlProjects,
-      companies: allGqlCompanies,
+      projects: storeNonNulls(allGqlProjects),
+      companies: storeNonNulls(allGqlCompanies),
       allLanguages,
       saveResult,
       isFromDB,


### PR DESCRIPTION
the api contained null values in companies/repositories...some issue with GQL returning non persistent results 
TODO: (some calls to GQL are ok some with error on same query) (see mongo logs)

Applied a temp patch where null values are filtered out from being stored in redis or stored